### PR TITLE
Fixed a bug with Text data type

### DIFF
--- a/Schema/data_types.alusus
+++ b/Schema/data_types.alusus
@@ -196,7 +196,7 @@
 
     class Text {
         @injection def dataType: DataType;
-        def length: int = 50;
+        def length: int = -1;
 
         handler this~init() {}
 
@@ -209,7 +209,14 @@
         }
 
         handler (this:DataType).generateSqlString(driver: ref[Driver]): String set_ptr {
-            return driver.mapDataType(String(1, "Text")) + "(" + this.length + ")";
+            if this.length == -1 return driver.mapDataType(String(1, "Text"))
+            else return driver.mapDataType(String(1, "Text")) + "(" + this.length + ")";
+        }
+
+        handler this_type(): SrdRef[DataType] {
+            def d: SrdRef[Text];
+            d.construct();
+            return castSrdRef[d, DataType];
         }
 
         handler this_type(length: int): SrdRef[DataType] {

--- a/صـفوف.أسس
+++ b/صـفوف.أسس
@@ -18,6 +18,7 @@
         عرف هل_بدئ_الاتصال: لقب isConnectionEstablished؛
         عرف هات_معطيات_الاتصال: لقب getConnectionParams؛
         عرف هات_آخر_خطأ: لقب getLastError؛
+        عرف نفذ: لقب exec؛
     }
 
     عرف قـيمة: لقب Value؛


### PR DESCRIPTION
Added a no-arg initializer for Text data type that can be used to specify a text data type without specifying a length. This is needed because PostgreSQL database does not allow length on `text` type.